### PR TITLE
Add support for darkmode

### DIFF
--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -2,44 +2,44 @@
 @header_height: @line_height;
 
 :root {
-	/* Used as the background color of the body */
-	/* Used as the text color for the borg screen of death */
-	/* Used as the text color for selected tabs (also if they are selected) */
+	/* Background color of the body */
+	/* Text color for the borg screen of death */
+	/* Text color for selected tabs (also if they are selected) */
 	--color-bg: #ffffff;
 	/* Background color for man messages */
 	--color-man-bg: #EDF3FF;
-	/* Used as the background color for the header bar */
-	/* Used as the line color between log messages */
+	/* Background color for the header bar */
+	/* Line color between log messages */
 	--color-header-bg: #eeeeee;
-	/* Used as the background color of the line that shows the builder (below the header) */
+	/* Background color of the line that shows the builder (below the header) */
 	--color-builder-bg: #FFFAAF;
 
-	/* Used as background color for the selected header tab if it is not focused */
-	/* Used as the foreground color for the header bar */
-	/* Used for unclicked links. */
+	/* Background color for the selected header tab if it is not focused */
+	/* Text color for the header bar */
+	/* Text color of unclicked links. */
 	--color-tab-selected: #005FFF;
-	/* Used as the background color for non-selected tabs */
-	/* Used as the background color for hovered, focused or active links */
+	/* Background color for non-selected tabs */
+	/* Background color for hovered, focused or active links */
 	--color-tab-unselected: #AFFFFF;
-	/* Used as the background color of the focused tab */
+	/* Background color of the focused tab */
 	--color-tab-focus: #DC00B8;
 	
-	/* Used as the default text color of the body */
+	/* Default text color of the body */
 	--color-text: #000000;
-	/* Used as the text color for ofborg and stomp messages */
-	/* Used as the color for the message that you require js */
-	/* Used as the text color of the line that shows the builder (below the header) */
+	/* Text color for ofborg and stomp messages */
+	/* Color of the message that you require js */
+	/* Text color of the line that shows the builder (below the header) */
 	--color-info: #00000080;
-	/* Used as text color for error messages */
+	/* Text color for error messages */
 	--color-error: #BA3300;
 
-	/* Used as the left border color for borg messages, like man or system information */
-	/* Used for background of the borg screen of death */
+	/* Left border color for borg messages, like man or system information */
+	/* Background of the borg screen of death */
 	--color-borg: #2D8F34;
-	/* Used as the left border color for man messages */
+	/* Left border color for man messages */
 	--color-man: #424775;
-	/* Used as the text color for stompjs debug messages */
-	/* Used for visited links */
+	/* Text color for stompjs debug messages */
+	/* Text color for visited links */
 	--color-debug: #8F2D87;
 }
 

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -4,7 +4,6 @@
 :root {
 	/* Background color of the body */
 	/* Text color for the borg screen of death */
-	/* Text color for selected tabs (also if they are selected) */
 	--color-bg: #ffffff;
 	/* Background color for man messages */
 	--color-man-bg: #EDF3FF;
@@ -13,23 +12,28 @@
 	--color-header-bg: #eeeeee;
 	/* Background color of the line that shows the builder (below the header) */
 	--color-builder-bg: #FFFAAF;
+	/* Foreground color of the line that shows the builder (below the header) */
+	--color-builder: #5270A3;
 
 	/* Background color for the selected header tab if it is not focused */
-	/* Text color for the header bar */
-	/* Text color of unclicked links. */
 	--color-tab-selected: #005FFF;
 	/* Background color for non-selected tabs */
 	/* Background color for hovered, focused or active links */
 	--color-tab-unselected: #AFFFFF;
 	/* Background color of the focused tab */
 	--color-tab-focus: #DC00B8;
+	/* Text color for the header bar */
+	/* Text color of unclicked links. */
+	--color-tab-text: var(--color-tab-selected);
+	/* Text color for selected tabs (also if they are selected) */
+	--color-tab-selected-text: var(--color-bg);
 	
 	/* Default text color of the body */
 	--color-text: #000000;
 	/* Text color for ofborg and stomp messages */
 	/* Color of the message that you require js */
 	/* Text color of the line that shows the builder (below the header) */
-	--color-info: #00000080;
+	--color-info: rgba(0, 0, 0, 0.5);
 	/* Text color for error messages */
 	--color-error: #BA3300;
 
@@ -41,6 +45,27 @@
 	/* Text color for stompjs debug messages */
 	/* Text color for visited links */
 	--color-debug: #8F2D87;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--color-bg: #1e1e1e;
+		--color-man-bg: #272727;
+		--color-header-bg: 	#303030; 
+		--color-builder-bg: #cd9309;
+		--color-builder:  rgba(0, 0, 0, 0.8);
+		--color-tab-selected: #444444;
+		--color-tab-unselected: #00000000;
+		--color-tab-focus: #4b4b4b;
+		--color-tab-text: var(--color-text);
+		--color-tab-selected-text: var(--color-text);
+		--color-text: #ffffff;
+		--color-info: rgba(255, 255, 255, 0.5);
+		--color-error: #ff7b63;
+		--color-borg: #26a269;
+		--color-man: #1a5fb4;
+		--color-debug: #613583;
+	}
 }
 
 #no-select {
@@ -88,7 +113,7 @@ body {
 
 .app > header {
 	background: var(--color-header-bg);
-	color: var(--color-tab-selected);
+	color: var(--color-tab-text);
 	height: @header_height;
 	z-index: 10;
 	position: sticky;
@@ -155,13 +180,13 @@ body {
 	}
 	li {
 		&:focus, &.__focus {
-			color: var(--color-bg);
+			color: var(--color-tab-selected-text);
 			background-color: var(--color-tab-focus);
 		}
 	}
 
 	.selected {
-		color: var(--color-bg);
+		color: var(--color-tab-selected-text);
 		background-color: var(--color-tab-selected);
 	}
 }
@@ -189,7 +214,7 @@ body {
 	}
 
 	a {
-		color: var(--color-tab-selected);
+		color: var(--color-tab-text);
 		text-decoration: underline;
 		&:hover, &:focus, &:active {
 			background-color: var(--color-tab-unselected);
@@ -205,7 +230,7 @@ body {
 		padding-left: @left_border/2;
 	}
 	.ofborg, .stomp {
-		color: var(--color-info-fg);
+		color: var(--color-info);
 	}
 
 	// And their (tagged) colors.
@@ -245,7 +270,7 @@ body {
 .logger .identity {
 	z-index: 1;
 	background: var(--color-builder-bg);
-	color: var(--color-info);
+	color: var(--color-builder);
 	min-height: @line_height;
 	position: sticky;
 	top: @header_height;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -1,15 +1,54 @@
-@color_borg: #2D8F34;
-@color_debug: #8F2D87;
-@color_man: #424775;
-@color_man_bg: #EDF3FF;
-@color_header_bg: #eeeeee;
-@color_header_fg: #005FFF;
-@color_tab_bg: #AFFFFF;
-@color_tab_selected: #ffffff;
-@color_tab_focus: #DC00B8;
-
 @line_height: 1.3rem;
 @header_height: @line_height;
+
+:root {
+	/* Used for background of the borg screen of death */
+	/* Used as the left border color for borg messages, like man or system information */
+	--color-borg: #2D8F34;
+	/* Used as the chat color for stompjs debug messages */
+	/* Used for visited links */
+	--color-debug: #8F2D87;
+	/* Used as the left border color for man messages */
+	--color-man: #424775;
+	/* Background color for man messages */
+	--color-man-bg: #EDF3FF;
+	/* Used as the background color for the header bar */
+	--color-header-bg: #eeeeee;
+	/* Used as the foreground color for the header bar */
+	/* Used for unclicked links. WHY? */
+	/* Used as background color for the selected header tab if it is not focused */
+	--color-header-fg: #005FFF;
+	/* Used as the background color for non-selected tabs */
+	/* Used as the background color for hovered, focused or active links */
+	--color-tab-bg: #AFFFFF;
+	/* Used as the text color for selected tabs (also if they are selected) */
+	--color-tab-selected: #ffffff;
+	/* Used as the background color of the focused tab */
+	--color-tab-focus: #DC00B8;
+
+	/* Used as the background color of the line that shows the builder (below the header) */
+	--color-builder-bg: #FFFAAF;
+	/* Used as the text color of the line that shows the builder (below the header) */
+	--color-builder-fg: #5270A3;
+
+	/* Used as the text color for ofborg and stomp messages */
+	--color-ofborg: #888;
+	/* Used as the color for the message that you require js */
+	--color-loading-js: #666;
+
+	/* Used as the background color of the body */
+	--color-background: #ffffff;
+	/* Used as the text color of the body */
+	--color-foreground: #000000;
+
+	/* used as the text color for the borg screen of death */
+	--color-white: #ffffff;
+	/* used as text color for error messages */
+	--color-error: #BA3300;
+
+	/* Used as the line color between log messages */
+	--color-line-divider: #eee;
+}
 
 #no-select {
 	-webkit-touch-callout: none;
@@ -22,8 +61,8 @@
 }
 
 body {
-	color: #000000;
-	background-color: #ffffff;
+	color: var(--color-foreground);
+	background-color: var(--color-background);
 	margin: 0;
 	padding: 0;
 	line-height: @line_height;
@@ -36,8 +75,8 @@ body {
 }
 
 .bsod {
-	background: @color_borg;
-	color: #ffffff;
+	background: var(--color-borg);
+	color: var(--color-white);
 	white-space: pre;
 }
 
@@ -46,7 +85,7 @@ body {
 		display: block;
 	}
 	em {
-		color: #666;
+		color: var(--color-loading-js);
 	}
 }
 
@@ -55,8 +94,8 @@ body {
 }
 
 .app > header {
-	background: @color_header_bg;
-	color: @color_header_fg;
+	background: var(--color-header-bg);
+	color: var(--color-header-fg);
 	height: @header_height;
 	z-index: 10;
 	position: sticky;
@@ -97,7 +136,7 @@ body {
 
 	ul > li {
 		display: inline-block;
-		background-color: @color_tab_bg;
+		background-color: var(--color-tab-bg);
 		margin-right: 1em;
 	}
 	li > * {
@@ -123,14 +162,14 @@ body {
 	}
 	li {
 		&:focus, &.__focus {
-			color: @color_tab_selected;
-			background-color: @color_tab_focus;
+			color: var(--color-tab-selected);
+			background-color: var(--color-tab-focus);
 		}
 	}
 
 	.selected {
-		color: @color_tab_selected;
-		background-color: @color_header_fg;
+		color: var(--color-tab-selected);
+		background-color: var(--color-header-fg);
 	}
 }
 
@@ -151,19 +190,19 @@ body {
 
 	// All lines.
 	& > * {
-		border-bottom: 0.05em solid #eee;
+		border-bottom: 0.05em solid var(--color-line-divider);
 		padding-left: @left_border;
 		min-height: @line_height;
 	}
 
 	a {
-		color: @color_header_fg;
+		color: var(--color-header-fg);
 		text-decoration: underline;
 		&:hover, &:focus, &:active {
-			background-color: @color_tab_bg;
+			background-color: var(--color-tab-bg);
 		}
 		&:visited {
-			color: @color_debug;
+			color: var(--color-debug);
 		}
 	}
 
@@ -173,22 +212,22 @@ body {
 		padding-left: @left_border/2;
 	}
 	.ofborg, .stomp {
-		color: #888;
+		color: var(--color-ofborg-fg);
 	}
 
 	// And their (tagged) colors.
 	.ofborg {
-		border-left-color: @color_borg;
+		border-left-color: var(--color-borg);
 	}
 	.stomp {
-		border-left-color: @color_debug;
+		border-left-color: var(--color-debug);
 	}
 	.stderr {
-		color: #BA3300;
+		color: var(--color-error);
 	}
 	.man {
-		border-left-color: @color_man;
-		background-color: @color_man_bg;
+		border-left-color: var(--color-man);
+		background-color: var(--color-man-bg);
 	}
 
 	// The previous bits of logs.
@@ -212,8 +251,8 @@ body {
 
 .logger .identity {
 	z-index: 1;
-	background: #FFFAAF;
-	color: #5270A3;
+	background: var(--color-builder-bg);
+	color: var(--color-builder-fg);
 	min-height: @line_height;
 	position: sticky;
 	top: @header_height;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -1,6 +1,3 @@
-@line_height: 1.3rem;
-@header_height: @line_height;
-
 :root {
 	/* Background color of the body */
 	/* Text color for the borg screen of death */
@@ -45,6 +42,11 @@
 	/* Text color for stompjs debug messages */
 	/* Text color for visited links */
 	--color-debug: #8F2D87;
+
+	/* Line height */
+	--line-height: 1.3rem;
+	/* Header height */
+	--header-height: var(--line-height);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -83,7 +85,7 @@ body {
 	background-color: var(--color-bg);
 	margin: 0;
 	padding: 0;
-	line-height: @line_height;
+	line-height: var(--line-height);
 	font-family:
 		"Go Mono",
 		"DejaVu Sans Mono",
@@ -114,7 +116,7 @@ body {
 .app > header {
 	background: var(--color-header-bg);
 	color: var(--color-tab-text);
-	height: @header_height;
+	height: var(--header-height);
 	z-index: 10;
 	position: sticky;
 	top: 0;
@@ -199,7 +201,7 @@ body {
 
 // A logger pane.
 .logger-log {
-	@left_border: 1em;
+	--left-border: 1em;
 
 	// Makes it mostly behave like pre.
 	// But with more wrapping.
@@ -209,8 +211,8 @@ body {
 	// All lines.
 	& > * {
 		border-bottom: 0.05em solid var(--color-header-bg);
-		padding-left: @left_border;
-		min-height: @line_height;
+		padding-left: var(--left-border);
+		min-height: var(--line-height);
 	}
 
 	a {
@@ -226,8 +228,8 @@ body {
 
 	// Specially tagged messages.
 	.ofborg, .stomp, .man {
-		border-left: @left_border/2 solid transparent;
-		padding-left: @left_border/2;
+		border-left: calc(var(--left-border) / 2) solid transparent;
+		padding-left: calc(var(--left-border) / 2);
 	}
 	.ofborg, .stomp {
 		color: var(--color-info);
@@ -246,10 +248,6 @@ body {
 	.man {
 		border-left-color: var(--color-man);
 		background-color: var(--color-man-bg);
-	}
-
-	// The previous bits of logs.
-	&.backlog {
 	}
 
 	// The "live" part of the logs.
@@ -271,20 +269,18 @@ body {
 	z-index: 1;
 	background: var(--color-builder-bg);
 	color: var(--color-builder);
-	min-height: @line_height;
+	min-height: var(--line-height);
 	position: sticky;
-	top: @header_height;
+	top: var(--header-height);
 	left: 0;
 	right: 0;
 }
 
 @keyframes flash {
-	@low: 0.1;
-
-	0%    {opacity: @low;}
+	0%    {opacity: 0.1;}
 	16.6% {opacity: 1;}
-	33.3% {opacity: @low;}
+	33.3% {opacity: 0.1;}
 	50%   {opacity: 1;}
-	66.6% {opacity: @low;}
+	66.6% {opacity: 0.1;}
 	100%  {opacity: 1;}
 }

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -2,52 +2,45 @@
 @header_height: @line_height;
 
 :root {
-	/* Used for background of the borg screen of death */
-	/* Used as the left border color for borg messages, like man or system information */
-	--color-borg: #2D8F34;
-	/* Used as the chat color for stompjs debug messages */
-	/* Used for visited links */
-	--color-debug: #8F2D87;
-	/* Used as the left border color for man messages */
-	--color-man: #424775;
+	/* Used as the background color of the body */
+	/* Used as the text color for the borg screen of death */
+	/* Used as the text color for selected tabs (also if they are selected) */
+	--color-bg: #ffffff;
 	/* Background color for man messages */
 	--color-man-bg: #EDF3FF;
 	/* Used as the background color for the header bar */
+	/* Used as the line color between log messages */
 	--color-header-bg: #eeeeee;
-	/* Used as the foreground color for the header bar */
-	/* Used for unclicked links. WHY? */
-	/* Used as background color for the selected header tab if it is not focused */
-	--color-header-fg: #005FFF;
-	/* Used as the background color for non-selected tabs */
-	/* Used as the background color for hovered, focused or active links */
-	--color-tab-bg: #AFFFFF;
-	/* Used as the text color for selected tabs (also if they are selected) */
-	--color-tab-selected: #ffffff;
-	/* Used as the background color of the focused tab */
-	--color-tab-focus: #DC00B8;
-
 	/* Used as the background color of the line that shows the builder (below the header) */
 	--color-builder-bg: #FFFAAF;
-	/* Used as the text color of the line that shows the builder (below the header) */
-	--color-builder-fg: #5270A3;
 
+	/* Used as background color for the selected header tab if it is not focused */
+	/* Used as the foreground color for the header bar */
+	/* Used for unclicked links. */
+	--color-tab-selected: #005FFF;
+	/* Used as the background color for non-selected tabs */
+	/* Used as the background color for hovered, focused or active links */
+	--color-tab-unselected: #AFFFFF;
+	/* Used as the background color of the focused tab */
+	--color-tab-focus: #DC00B8;
+	
+	/* Used as the default text color of the body */
+	--color-text: #000000;
 	/* Used as the text color for ofborg and stomp messages */
-	--color-ofborg: #888;
 	/* Used as the color for the message that you require js */
-	--color-loading-js: #666;
-
-	/* Used as the background color of the body */
-	--color-background: #ffffff;
-	/* Used as the text color of the body */
-	--color-foreground: #000000;
-
-	/* used as the text color for the borg screen of death */
-	--color-white: #ffffff;
-	/* used as text color for error messages */
+	/* Used as the text color of the line that shows the builder (below the header) */
+	--color-info: #00000080;
+	/* Used as text color for error messages */
 	--color-error: #BA3300;
 
-	/* Used as the line color between log messages */
-	--color-line-divider: #eee;
+	/* Used as the left border color for borg messages, like man or system information */
+	/* Used for background of the borg screen of death */
+	--color-borg: #2D8F34;
+	/* Used as the left border color for man messages */
+	--color-man: #424775;
+	/* Used as the text color for stompjs debug messages */
+	/* Used for visited links */
+	--color-debug: #8F2D87;
 }
 
 #no-select {
@@ -61,8 +54,8 @@
 }
 
 body {
-	color: var(--color-foreground);
-	background-color: var(--color-background);
+	color: var(--color-text);
+	background-color: var(--color-bg);
 	margin: 0;
 	padding: 0;
 	line-height: @line_height;
@@ -76,7 +69,7 @@ body {
 
 .bsod {
 	background: var(--color-borg);
-	color: var(--color-white);
+	color: var(--color-bg);
 	white-space: pre;
 }
 
@@ -85,7 +78,7 @@ body {
 		display: block;
 	}
 	em {
-		color: var(--color-loading-js);
+		color: var(--color-info);
 	}
 }
 
@@ -95,7 +88,7 @@ body {
 
 .app > header {
 	background: var(--color-header-bg);
-	color: var(--color-header-fg);
+	color: var(--color-tab-selected);
 	height: @header_height;
 	z-index: 10;
 	position: sticky;
@@ -136,7 +129,7 @@ body {
 
 	ul > li {
 		display: inline-block;
-		background-color: var(--color-tab-bg);
+		background-color: var(--color-tab-unselected);
 		margin-right: 1em;
 	}
 	li > * {
@@ -162,14 +155,14 @@ body {
 	}
 	li {
 		&:focus, &.__focus {
-			color: var(--color-tab-selected);
+			color: var(--color-bg);
 			background-color: var(--color-tab-focus);
 		}
 	}
 
 	.selected {
-		color: var(--color-tab-selected);
-		background-color: var(--color-header-fg);
+		color: var(--color-bg);
+		background-color: var(--color-tab-selected);
 	}
 }
 
@@ -190,16 +183,16 @@ body {
 
 	// All lines.
 	& > * {
-		border-bottom: 0.05em solid var(--color-line-divider);
+		border-bottom: 0.05em solid var(--color-header-bg);
 		padding-left: @left_border;
 		min-height: @line_height;
 	}
 
 	a {
-		color: var(--color-header-fg);
+		color: var(--color-tab-selected);
 		text-decoration: underline;
 		&:hover, &:focus, &:active {
-			background-color: var(--color-tab-bg);
+			background-color: var(--color-tab-unselected);
 		}
 		&:visited {
 			color: var(--color-debug);
@@ -212,7 +205,7 @@ body {
 		padding-left: @left_border/2;
 	}
 	.ofborg, .stomp {
-		color: var(--color-ofborg-fg);
+		color: var(--color-info-fg);
 	}
 
 	// And their (tagged) colors.
@@ -252,7 +245,7 @@ body {
 .logger .identity {
 	z-index: 1;
 	background: var(--color-builder-bg);
-	color: var(--color-builder-fg);
+	color: var(--color-info);
 	min-height: @line_height;
 	position: sticky;
 	top: @header_height;


### PR DESCRIPTION
This PR adjusts the stylesheet to enable darkmode if the user `prefers-color-scheme: dark`. 

To build ofborg-viewer you need to use an old nix channel that includes nodejs 6. Building with 18-03 (`https://nixos.org/channels/nixos-18.03`) seemed to work for me.
